### PR TITLE
chore(tools): add clang-format/tidy + CI (firmware/app only)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100
+DerivePointerAlignment: false
+PointerAlignment: Left
+AllowShortFunctionsOnASingleLine: Empty

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,8 @@
+Checks: >
+  bugprone-*,clang-analyzer-*,performance-*,portability-*,readability-*
+  ,-readability-magic-numbers
+  ,-readability-identifier-length
+  ,-readability-function-size
+WarningsAsErrors: ''
+HeaderFilterRegex: '^firmware/app/'
+FormatStyle: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: ci
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: firmware
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format clang-tidy
+      - name: clang-format & clang-tidy (app/)
+        run: |
+          set -euo pipefail
+          FILES=$(git ls-files ':(glob)app/**/*.c' ':(glob)app/**/*.h' || true)
+          if [ -n "$FILES" ]; then
+            clang-format --dry-run --Werror $FILES
+            for f in $FILES; do
+              case "$f" in *.c) clang-tidy "$f" -- -Iapp -std=c11 ;; esac
+            done
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,8 @@ jobs:
         working-directory: firmware
     steps:
       - uses: actions/checkout@v4
-      - run: |
+      - name: Install clang tools
+        run: |
           sudo apt-get update
           sudo apt-get install -y clang-format clang-tidy
       - name: clang-format & clang-tidy (app/)
@@ -17,20 +18,18 @@ jobs:
           set -euo pipefail
           FILES=$(git ls-files ':(glob)app/**/*.c' ':(glob)app/**/*.h' || true)
           if [ -n "$FILES" ]; then
+            echo "Checking format…"
             clang-format --dry-run --Werror $FILES
+            echo "Running clang-tidy on app files (skipping HAL/USB-coupled ones)…"
             for f in $FILES; do
               case "$f" in
-                app/board_*.c) continue ;;  # skip HAL-coupled board files
+                app/board_*.c|app/comm_usb_cdc.c) continue ;;  # skip files that need HAL/USB headers
                 *.c)
-                  clang-tidy "$f" -- \
-                    -I. -Iapp \
-                    -IUSB_DEVICE/App -IUSB_DEVICE/Target \
-                    -IMiddlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc \
-                    -IMiddlewares/ST/STM32_USB_Device_Library/Core/Inc \
-                    -ICore/Inc \
-                    -std=c11 \
-                    -header-filter='^app/'
+                  # Only app include paths; no vendor/USB/HAL includes
+                  clang-tidy "$f" -- -I. -Iapp -std=c11
                   ;;
               esac
             done
+          else
+            echo "No app files; skipping."
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,13 @@ jobs:
                 app/board_*.c) continue ;;  # skip HAL-coupled board files
                 *.c)
                   clang-tidy "$f" -- \
-                    -I. -Iapp -IUSB_DEVICE/App -ICore/Inc -std=c11
+                    -I. -Iapp \
+                    -IUSB_DEVICE/App -IUSB_DEVICE/Target \
+                    -IMiddlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc \
+                    -IMiddlewares/ST/STM32_USB_Device_Library/Core/Inc \
+                    -ICore/Inc \
+                    -std=c11 \
+                    -header-filter='^app/'
                   ;;
               esac
             done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,12 @@ jobs:
           if [ -n "$FILES" ]; then
             clang-format --dry-run --Werror $FILES
             for f in $FILES; do
-              case "$f" in *.c) clang-tidy "$f" -- -Iapp -std=c11 ;; esac
+              case "$f" in
+                app/board_*.c) continue ;;  # skip HAL-coupled board files
+                *.c)
+                  clang-tidy "$f" -- \
+                    -I. -Iapp -IUSB_DEVICE/App -ICore/Inc -std=c11
+                  ;;
+              esac
             done
           fi

--- a/firmware/app/board.h
+++ b/firmware/app/board.h
@@ -13,7 +13,9 @@ extern "C" {
 uint32_t board_millis(void);
 
 /** Timebase in Hz for board_millis() (usually 1000). */
-static inline uint32_t board_timebase_hz(void) { return 1000u; }
+static inline uint32_t board_timebase_hz(void) {
+    return 1000u;
+}
 
 #ifdef __cplusplus
 }

--- a/firmware/app/comm_usb_cdc.h
+++ b/firmware/app/comm_usb_cdc.h
@@ -4,8 +4,8 @@
  */
 
 #pragma once
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -42,9 +42,7 @@ int comm_usb_cdc_write(const void* buf, uint16_t len);
  */
 void comm_usb_cdc_set_rx_handler(comm_rx_handler_t cb);
 
-
 /* ------- link gating + pump API ------- */
-
 
 /** Forward-declaration of ring type. */
 struct rb_t;

--- a/firmware/app/protocol.c
+++ b/firmware/app/protocol.c
@@ -5,26 +5,25 @@
  *          proto_apply_commands(): applies 1-byte START/STOP to a streaming flag.
  *          Pure helpers; no global state or hardware access.
  */
-#include "app/protocol_defs.h"
 #include <string.h>
 
-size_t proto_write_stream_frame(uint8_t* out, size_t out_cap,
-                                const uint8_t* payload, uint16_t payload_len,
-                                uint32_t seq, uint32_t ts_ms)
-{
+#include "app/protocol_defs.h"
+
+size_t proto_write_stream_frame(uint8_t* out, size_t out_cap, const uint8_t* payload,
+                                uint16_t payload_len, uint32_t seq, uint32_t ts_ms) {
     if (!out || !payload || payload_len == 0) return 0;
-    if (payload_len > PROTO_MAX_PAYLOAD)      payload_len = PROTO_MAX_PAYLOAD;
+    if (payload_len > PROTO_MAX_PAYLOAD) payload_len = PROTO_MAX_PAYLOAD;
 
     const size_t need = sizeof(proto_stream_hdr_t) + (size_t)payload_len;
     if (out_cap < need) return 0;
 
     proto_stream_hdr_t h;
     h.magic = PROTO_MAGIC;
-    h.type  = PROTO_TYPE_STREAM;
-    h.ver   = PROTO_VERSION;
-    h.len   = payload_len;
-    h.rsv   = 0;
-    h.seq   = seq;
+    h.type = PROTO_TYPE_STREAM;
+    h.ver = PROTO_VERSION;
+    h.len = payload_len;
+    h.rsv = 0;
+    h.seq = seq;
     h.ts_ms = ts_ms;
 
     memcpy(out, &h, sizeof h);
@@ -32,14 +31,18 @@ size_t proto_write_stream_frame(uint8_t* out, size_t out_cap,
     return need;
 }
 
-void proto_apply_commands(const uint8_t* data, size_t len, uint8_t* io_streaming)
-{
+void proto_apply_commands(const uint8_t* data, size_t len, uint8_t* io_streaming) {
     if (!data || !io_streaming) return;
     for (size_t i = 0; i < len; ++i) {
         switch (data[i]) {
-            case PROTO_CMD_START: *io_streaming = 1; break;
-            case PROTO_CMD_STOP:  *io_streaming = 0; break;
-            default: break;
+            case PROTO_CMD_START:
+                *io_streaming = 1;
+                break;
+            case PROTO_CMD_STOP:
+                *io_streaming = 0;
+                break;
+            default:
+                break;
         }
     }
 }

--- a/firmware/app/protocol_defs.h
+++ b/firmware/app/protocol_defs.h
@@ -3,34 +3,34 @@
  * @brief   Tiny framing protocol: header layout + helpers + command opcodes.
  */
 #pragma once
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /* --- constants --- */
-#define PROTO_MAGIC          0x5AA5u   /* on the wire: A5 5A (LE) */
-#define PROTO_VERSION        0u
-#define PROTO_TYPE_STREAM    0u        /* room for more types later */
-#define PROTO_MAX_PAYLOAD  512u        /* per-frame cap we use today */
+#define PROTO_MAGIC 0x5AA5u /* on the wire: A5 5A (LE) */
+#define PROTO_VERSION 0u
+#define PROTO_TYPE_STREAM 0u   /* room for more types later */
+#define PROTO_MAX_PAYLOAD 512u /* per-frame cap we use today */
 
 /* --- 16-byte packed header --- */
 typedef struct __attribute__((packed)) {
-    uint16_t magic;     /* PROTO_MAGIC */
-    uint8_t  type;      /* PROTO_TYPE_STREAM */
-    uint8_t  ver;       /* PROTO_VERSION */
-    uint16_t len;       /* payload bytes (<= PROTO_MAX_PAYLOAD) */
-    uint16_t rsv;       /* 0 for now */
-    uint32_t seq;       /* host can spot gaps */
-    uint32_t ts_ms;     /* device time (board_millis) */
+    uint16_t magic; /* PROTO_MAGIC */
+    uint8_t type;   /* PROTO_TYPE_STREAM */
+    uint8_t ver;    /* PROTO_VERSION */
+    uint16_t len;   /* payload bytes (<= PROTO_MAX_PAYLOAD) */
+    uint16_t rsv;   /* 0 for now */
+    uint32_t seq;   /* host can spot gaps */
+    uint32_t ts_ms; /* device time (board_millis) */
 } proto_stream_hdr_t;
 
 /* --- commands (1-byte opcodes) --- */
 typedef enum {
     PROTO_CMD_START = 0x01,
-    PROTO_CMD_STOP  = 0x02,
+    PROTO_CMD_STOP = 0x02,
 } proto_cmd_t;
 
 /* --- helpers --- */
@@ -47,9 +47,8 @@ typedef enum {
  *
  * Note: copies header via memcpy; 'out' can be any alignment.
  */
-size_t proto_write_stream_frame(uint8_t* out, size_t out_cap,
-                                const uint8_t* payload, uint16_t payload_len,
-                                uint32_t seq, uint32_t ts_ms);
+size_t proto_write_stream_frame(uint8_t* out, size_t out_cap, const uint8_t* payload,
+                                uint16_t payload_len, uint32_t seq, uint32_t ts_ms);
 
 /**
  * @brief Apply a stream of 1-byte commands to a streaming flag.

--- a/firmware/app/ps_app.c
+++ b/firmware/app/ps_app.c
@@ -6,19 +6,21 @@
  */
 
 #include "app/ps_app.h"
-#include "app/ps_config.h"
-#include "app/board.h"
-#include "app/comm_usb_cdc.h"
-#include "app/ring_buffer.h"
-#include "app/protocol_defs.h"
+
 #include <string.h>
 
-static uint8_t s_streaming = 1;   // 1=on, 0=off
+#include "app/board.h"
+#include "app/comm_usb_cdc.h"
+#include "app/protocol_defs.h"
+#include "app/ps_config.h"
+#include "app/ring_buffer.h"
+
+static uint8_t s_streaming = 1;  // 1=on, 0=off
 /* ---------- Ring buffer instances ---------- */
 static uint8_t tx_mem[PS_TX_RING_CAP];
 static uint8_t rx_mem[PS_RX_RING_CAP];
-static rb_t    txring;
-static rb_t    rxring;
+static rb_t txring;
+static rb_t rxring;
 
 static uint32_t s_seq = 0;
 
@@ -28,12 +30,10 @@ static void on_usb_rx(const uint8_t* d, uint32_t n) {
 }
 
 /* Public-ish: wrap payload in header and enqueue to TX ring */
-static void ps_send_frame(const uint8_t* payload, uint16_t payload_len)
-{
+static void ps_send_frame(const uint8_t* payload, uint16_t payload_len) {
     uint8_t buf[sizeof(proto_stream_hdr_t) + PROTO_MAX_PAYLOAD] __attribute__((aligned(4)));
-    size_t n = proto_write_stream_frame(buf, sizeof buf,
-                                        payload, payload_len,
-                                        s_seq++, board_millis());
+    size_t n =
+        proto_write_stream_frame(buf, sizeof buf, payload, payload_len, s_seq++, board_millis());
     if (n) rb_write(&txring, buf, (uint16_t)n);
 }
 
@@ -53,8 +53,7 @@ static void ps_parse_commands(void) {
     }
 }
 
-void ps_app_init(void)
-{
+void ps_app_init(void) {
     rb_init(&txring, tx_mem, PS_TX_RING_CAP);
     rb_init(&rxring, rx_mem, PS_RX_RING_CAP);
 
@@ -65,15 +64,13 @@ void ps_app_init(void)
 }
 
 /* Generate a small test payload → later swap with INA219 samples */
-static void ps_fill_test_payload(uint8_t* dst, uint16_t len)
-{
+static void ps_fill_test_payload(uint8_t* dst, uint16_t len) {
     static uint8_t phase = 0;
     for (uint16_t i = 0; i < len; ++i) dst[i] = (uint8_t)(phase + i);
     phase += 1;
 }
 
-void ps_app_tick(void)
-{
+void ps_app_tick(void) {
     static uint32_t last_gen = 0;
     uint32_t now = board_millis();
 

--- a/firmware/app/ps_app.h
+++ b/firmware/app/ps_app.h
@@ -5,7 +5,6 @@
  * Call ps_app_init() once after USB init; call ps_app_tick() in main loop.
  */
 
-
 #pragma once
 #include <stdint.h>
 
@@ -17,7 +16,7 @@ extern "C" {
 void ps_app_init(void);
 
 /** Run periodic work: produce payload (current build), pump USB, parse commands. */
-void ps_app_tick(void);   // call from the main loop
+void ps_app_tick(void);  // call from the main loop
 
 #ifdef __cplusplus
 }

--- a/firmware/app/ps_config.h
+++ b/firmware/app/ps_config.h
@@ -6,20 +6,20 @@
 #include <stdint.h>
 
 // Ring sizes (power-of-two, ≤ 65536)
-#define PS_TX_RING_CAP          8192u
-#define PS_RX_RING_CAP          2048u
+#define PS_TX_RING_CAP 8192u
+#define PS_RX_RING_CAP 2048u
 
 // Stream cadence and payload size for the current build
-#define PS_STREAM_PERIOD_MS        5u
-#define PS_STREAM_PAYLOAD_LEN    128u
+#define PS_STREAM_PERIOD_MS 5u
+#define PS_STREAM_PAYLOAD_LEN 128u
 
 // bytes to parse per tick (64–256 is typical)
-#define PS_CMD_BUDGET_PER_TICK  256u   
+#define PS_CMD_BUDGET_PER_TICK 256u
 
 // compile-time sanity
 #if ((PS_TX_RING_CAP & (PS_TX_RING_CAP - 1)) || PS_TX_RING_CAP > 65536)
-# error "PS_TX_RING_CAP must be power-of-two and ≤ 65536"
+#error "PS_TX_RING_CAP must be power-of-two and ≤ 65536"
 #endif
 #if ((PS_RX_RING_CAP & (PS_RX_RING_CAP - 1)) || PS_RX_RING_CAP > 65536)
-# error "PS_RX_RING_CAP must be power-of-two and ≤ 65536"
+#error "PS_RX_RING_CAP must be power-of-two and ≤ 65536"
 #endif


### PR DESCRIPTION
Adds .clang-format & .clang-tidy
CI workflow lints firmware/app/** only; skips vendor & HAL-coupled files
No firmware behavior changes